### PR TITLE
Version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ en:
       your_requests:
         explanation: An admin will approve or deny access
         name: Your access requests
+      admin:
+        your_requests:
+          help:
+            - User requests access against the registered workflow
+            - An admin will review the request
+            - Admin will either approve or reject the access request
+            - The user will get notified that their access request has been either approved or rejected
 ```
 
 ## Usage

--- a/lib/decidim/access_requests/version.rb
+++ b/lib/decidim/access_requests/version.rb
@@ -3,6 +3,6 @@
 module Decidim
   module AccessRequests
     VERSION = "0.16.1"
-    DECIDIM_VERSION = "~> 0.16.0"
+    DECIDIM_VERSION = "~> 0.16"
   end
 end


### PR DESCRIPTION
This pull request is just to let you know that your plugin works fine with 0.17 version of Decidim.
I'm not sure how you want to handle versions, so this changes allows to work on both 0.16 and 0.17 versions.

Additional, version 0.17 of Decidim adds and extra key for verification methods used on the help page. I've updated the README with an example.

Feel free to discard this pull-request if you have a better solution. Thanks